### PR TITLE
Include DEAP and adapt

### DIFF
--- a/ADR/Analysis/Performance/Power.py
+++ b/ADR/Analysis/Performance/Power.py
@@ -23,14 +23,16 @@ class Power:
         positive_power = (self.power_excess_df['Power excess'] > 0)
         has_power_excess = positive_power.any()
 
-        while has_power_excess == False:
-            self.plane.mtow -= 0.1
+        while has_power_excess == False and self.plane.mtow != 0:
+            self.plane.mtow -= 1 #TODO: This is a big reduce-step. We should get this down by getting the power analysis time down.
+            print('New MTOW: {}'.format(self.plane.mtow))
             if self.plane.mtow >0:
                 self.power_available()
                 self.power_required()
                 self.power_excess()
             else:
-                raise ValueError('Aircraft cannot sustain flight even with zero weight')
+                self.plane.mtow = 0
+                print('Aircraft cannot sustain flight even with zero weight')
 
         self.get_V_min_max()
 
@@ -114,7 +116,10 @@ class Power:
             self.plane.V_max = roots[1]
             alpha_max = np.interp(self.plane.V_min, self.alpha_df.index.values, self.alpha_df['Alpha'])
         elif len(roots) == 0:
-            raise ValueError ('Airplane has no power excess! Get this drag down or buy a new motor!')
+            self.plane.V_min = V_stall
+            self.plane.V_max = 25
+            alpha_max = np.interp(self.plane.V_min, self.alpha_df.index.values, self.alpha_df['Alpha'])
+            print('Airplane has no power excess! Get this drag down or buy a new motor!')
         self.plane.alpha_min = self.alpha_dict[self.plane.V_max]
 
         self.plane.alpha_max = alpha_max

--- a/ADR/Checkers/Scoreboard.py
+++ b/ADR/Checkers/Scoreboard.py
@@ -14,4 +14,5 @@ class MaybeAnAssassin:
             print('Plane is alive and scored {}'.format(self.plane.score))
         else:
             self.plane.dead = True
+            self.plane.score = -1000
             print('Plane is dead')

--- a/ADR/Components/Plane.py
+++ b/ADR/Components/Plane.py
@@ -11,7 +11,7 @@ import numpy as np
 
 class Plane:
     def __init__(self, data):
-
+        self.data = data
         self.plane_type = data.get("plane_type")
 
         wing1_data = {
@@ -175,48 +175,83 @@ class Plane:
         return self.V_stall
 
     def show_plane(self):
-        print("\nPlane components:\n")
+        pass
+        # print('-------------------------------------------------------------')
 
-        print("\t--- ", self.wing1, " ---")
-        print("\tairfoil1 = ", self.wing1.airfoil1)
-        print("\tairfoil2 = ", self.wing1.airfoil2)
-        print("\tspan1 = ", self.wing1.span1)
-        print("\tspan2 = ", self.wing1.span2)
-        print("\tchord1 = ", self.wing1.chord1)
-        print("\tchord2 = ", self.wing1.chord2)
-        print("\tchord3 = ", self.wing1.chord3)
-        print("\ttwist1 = ", self.wing1.twist1)
-        print("\ttwist2 = ", self.wing1.twist2)
-        print("\ttwist3 = ", self.wing1.twist3)
-        print("\tincidence = ", self.wing1.incidence)
-        print("\tca.x = ", self.wing1.ca.x)
-        print("\tca.z = ", self.wing1.ca.z)
-        print("\tstall_min = ", self.wing1.stall_min)
-        print("\tstall_max = ", self.wing1.stall_max)
-        print("\tdownwash_angle = ", self.wing1.downwash_angle)
-        print()
+        # print("\nPlane components:\n")
 
-        print("\t--- ", self.hs, " ---")
-        print("\tairfoil1 = ", self.hs.airfoil1)
-        print("\tairfoil2 = ", self.hs.airfoil2)
-        print("\tspan1 = ", self.hs.span1)
-        print("\tspan2 = ", self.hs.span2)
-        print("\tchord1 = ", self.hs.chord1)
-        print("\tchord2 = ", self.hs.chord2)
-        print("\tchord3 = ", self.hs.chord3)
-        print("\ttwist1 = ", self.hs.twist1)
-        print("\ttwist2 = ", self.hs.twist2)
-        print("\ttwist3 = ", self.hs.twist3)
-        print("\tincidence = ", self.hs.incidence)
-        print("\tca.x = ", self.hs.ca.x)
-        print("\tca.z = ", self.hs.ca.z)
-        print("\tstall_min = ", self.hs.stall_min)
-        print("\tstall_max = ", self.hs.stall_max)
-        print("\tdownwash_angle = ", self.hs.downwash_angle)
-        print()
+        # print("\t--- ", self.wing1, " ---")
+        # "x": data.get("wing1_x"),
+        # "y": data.get("wing1_y"),
+        # "z": data.get("wing1_z"),
+        # "airfoil_clmax": data.get("wing1_clmax_airfoil"),
+        # "airfoil1_name": data.get("wing1_airfoil1_name"),
+        # "airfoil2_name": data.get("wing1_airfoil2_name"),
+        # "airfoil3_name": data.get("wing1_airfoil3_name"),
+        # "span1": data.get("wing1_span1"),
+        # "span2": data.get("wing1_span2"),
+        # "chord1": data.get("wing1_chord1"),
+        # "chord2": data.get("wing1_chord2"),
+        # "chord3": data.get("wing1_chord3"),
+        # "twist1": data.get("wing1_twist1"),
+        # "twist2": data.get("wing1_twist2"),
+        # "twist3": data.get("wing1_twist3"),
+        # "incidence": data.get("wing1_incidence"),
+        # "CM_ca": data.get("wing1_CM_ca"),
+        # print()
 
-        print("\t--- ", self.cg, " ---")
-        print("\tcg.x = ", self.cg.x)
-        print("\tcg.z = ", self.cg.z)
+        # print("\t--- ", self.wing2, " ---")
+        # "x": data.get("wing2_x"),
+        # "y": data.get("wing2_y"),
+        # "z": data.get("wing2_z"),
+        # "airfoil_clmax": data.get("wing2_clmax_airfoil"),
+        # "airfoil1_name": data.get("wing2_airfoil1_name"),
+        # "airfoil2_name": data.get("wing2_airfoil2_name"),
+        # "airfoil3_name": data.get("wing2_airfoil3_name"),
+        # "span1": data.get("wing2_span1"),
+        # "span2": data.get("wing2_span2"),
+        # "chord1": data.get("wing2_chord1"),
+        # "chord2": data.get("wing2_chord2"),
+        # "chord3": data.get("wing2_chord3"),
+        # "twist1": data.get("wing2_twist1"),
+        # "twist2": data.get("wing2_twist2"),
+        # "twist3": data.get("wing2_twist3"),
+        # "incidence": data.get("wing2_incidence"),
+        # "CM_ca": data.get("wing2_CM_ca"),
+        # print()
 
-        print()
+        # print("\t--- ", self.hs, " ---")
+        # "x": data.get("hs_x"),
+        # "y": data.get("hs_y"),
+        # "z": data.get("hs_z"),
+        # "airfoil_clmax": data.get("hs_clmax_airfoil"),
+        # "airfoil1_name": data.get("hs_airfoil1_name"),
+        # "airfoil2_name": data.get("hs_airfoil2_name"),
+        # "airfoil3_name": data.get("hs_airfoil3_name"),
+        # "span1": data.get("hs_span1"),
+        # "span2": data.get("hs_span2"),
+        # "chord1": data.get("hs_chord1"),
+        # "chord2": data.get("hs_chord2"),
+        # "chord3": data.get("hs_chord3"),
+        # "twist1": data.get("hs_twist1"),
+        # "twist2": data.get("hs_twist2"),
+        # "twist3": data.get("hs_twist3"),
+        # "incidence": data.get("hs_incidence"),
+        # "CM_ca": data.get("hs_CM_ca"),
+        # print()
+
+        # "x": data.get("motor_x"),
+        # "y": data.get("motor_y"),
+        # "z": data.get("motor_z"),
+        # "static_thrust": data.get("static_thrust"),
+        # "linear_decay_coefficient": data.get("linear_decay_coefficient")
+        # print()
+
+        # "x": data.get("cg_x"),
+        # "z": data.get("cg_z")
+        # print()
+
+        # "x": data.get("tpr_x"),
+        # "z": data.get("tpr_z")
+        # print()
+        # print('-------------------------------------------------------------')

--- a/ADR/Methods/VLM/AVL/avl_runner.py
+++ b/ADR/Methods/VLM/AVL/avl_runner.py
@@ -1,4 +1,4 @@
-import subprocess
+from subprocess import Popen, PIPE, STDOUT, DEVNULL
 import os
 from math import radians
 import numpy as np
@@ -52,12 +52,11 @@ def get_aero_coef(Cl_max_airfoil):
     open(output_file, 'a').close()
     open(output2_file, 'a').close()
 
-
     for alpha in alpha_range:
         os.remove(output_file)
         os.remove(output2_file)
         comm_string = 'load {}\n oper\n a\n a\n {}\n x\n ft\n{}\nfs\n{}\n'.format(config_file, alpha, output_file, output2_file)
-        Process=subprocess.Popen([avl_file], stdin=subprocess.PIPE, shell = True)
+        Process=Popen([avl_file], stdin=PIPE, stdout=DEVNULL , stderr=STDOUT)
         Process.communicate(bytes(comm_string, encoding='utf8'))
         if get_clmax(output2_file) > Cl_max_airfoil:
             break

--- a/ADR/Methods/VLM/AVL/io_avl.py
+++ b/ADR/Methods/VLM/AVL/io_avl.py
@@ -23,7 +23,7 @@ def get_clmax(output):
                 print(line.replace('\n',''))
 
 
-    fid_df = pd.read_csv(output, skiprows=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,20], skipfooter=28, delim_whitespace=True)
+    fid_df = pd.read_csv(output, skiprows=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,20], skipfooter=28, delim_whitespace=True, engine='python')
     fid_df.set_index('j', inplace=True)
     cl_max = fid_df['cl'].max()
     return cl_max

--- a/ADR/main.py
+++ b/ADR/main.py
@@ -1,4 +1,5 @@
 from ADR import parameters
+from ADR import parameters_optmizer
 from ADR.Components.Plane import Plane
 from ADR.Analysis.Performance.Takeoff import Takeoff
 from ADR.Analysis.Performance.test_Takeoff import plot_takeoff_data
@@ -14,37 +15,51 @@ from ADR.Checkers.Scoreboard import MaybeAnAssassin
 from matplotlib import pyplot as plt
 import numpy as np
 
-plot = True
+plot = False
 
-plane_data = parameters.plane_data()
-performance_data = parameters.performance_data()
+def adr_analyser(individual):
 
-plane = Plane(plane_data)
+    airplane_var_data = parameters_optmizer.enter_parameters(individual)
 
-takeoff_analysis = Takeoff(plane, performance_data)
-mtow = takeoff_analysis.get_mtow()
-plot_takeoff_data(takeoff_analysis, mtow)
+    plane_data = parameters_optmizer.plane_data(airplane_var_data)
+    performance_data = parameters.performance_data()
 
-print('Initial MTOW is {}'.format(mtow))
+    plane = Plane(plane_data)
+    plane.show_plane()
 
-flight_stability = FlightStability(plane)
-flight_stability.CM_plane_CG(plane.cg)
-flight_stability.static_margin()
-plot_stability_data(flight_stability)
+    print('Plane parameters: {}'.format(individual))
 
-power_analysis = Power(plane, performance_data)
-plot_power_curves(power_analysis)
+    takeoff_analysis = Takeoff(plane, performance_data)
+    mtow = takeoff_analysis.get_mtow()
 
-trimm_range_checker = TrimmRangeChecker(plane)
-trimm_range_checker.check()
+    print('Initial MTOW is {}'.format(mtow))
 
-sm_checker = StaticMarginChecker(plane)
-sm_checker.check()
+    flight_stability = FlightStability(plane)
+    flight_stability.CM_plane_CG(plane.cg)
+    flight_stability.static_margin()
 
-maybe_an_assassin = MaybeAnAssassin(plane)
-maybe_an_assassin.score_or_kill()
+    power_analysis = Power(plane, performance_data)
 
-print('Final MTOW is {}'.format(mtow))
+    trimm_range_checker = TrimmRangeChecker(plane)
+    trimm_range_checker.check()
 
-if plot == True:
-    plt.show()
+    sm_checker = StaticMarginChecker(plane)
+    sm_checker.check()
+
+    maybe_an_assassin = MaybeAnAssassin(plane)
+    maybe_an_assassin.score_or_kill()
+
+    print('Final MTOW is {}'.format(mtow))
+
+    if plot == True:
+        plot_takeoff_data(takeoff_analysis, mtow)
+        plot_stability_data(flight_stability)
+        plot_power_curves(power_analysis)
+        plt.show()
+
+    return plane.score,
+
+if __name__ == "__main__":
+    plot = True
+    plane_data = parameters.plane_data()
+    adr_analyser(plane_data)

--- a/ADR/optmizer.py
+++ b/ADR/optmizer.py
@@ -1,0 +1,54 @@
+import numpy
+
+from deap import algorithms
+from deap import base
+from deap import benchmarks
+from deap import cma
+from deap import creator
+from deap import tools
+
+import random
+
+from ADR.main import adr_analyser
+from ADR.parameters_optmizer import plane_data, enter_parameters
+
+N=4
+creator.create("FitnessMax", base.Fitness, weights=(1.0,))
+creator.create("Individual", list, fitness=creator.FitnessMax)
+
+toolbox = base.Toolbox()
+toolbox.register("attr_bool", random.uniform, 0, 1)
+toolbox.register("individual", tools.initRepeat, creator.Individual, toolbox.attr_bool, n=4)
+toolbox.register("population", tools.initRepeat, list, toolbox.individual)
+
+toolbox.register("evaluate", adr_analyser)
+
+toolbox.register("mate", tools.cxTwoPoint)
+toolbox.register("mutate", tools.mutFlipBit, indpb=0.10)
+toolbox.register("select", tools.selTournament, tournsize=2)
+
+def main():
+    pop = toolbox.population(n=10)
+    hof = tools.HallOfFame(1)
+    stats = tools.Statistics(lambda ind: ind.fitness.values)
+    stats.register("avg", numpy.mean)
+    stats.register("min", numpy.min)
+    stats.register("max", numpy.max)
+
+    pop, logbook = algorithms.eaSimple(pop, toolbox, cxpb=0.5, mutpb=0.2, ngen=2, stats=stats, halloffame=hof, verbose=True)
+
+    return pop, logbook, hof
+
+if __name__ == "__main__":
+    pop, log, hof = main()
+    print("Best individual is: %s\nwith fitness: %s" % (hof[0], hof[0].fitness))
+
+    import matplotlib.pyplot as plt
+    gen, avg, min_, max_ = log.select("gen", "avg", "min", "max")
+    plt.plot(gen, avg, label="average")
+    plt.plot(gen, min_, label="minimum")
+    plt.plot(gen, max_, label="maximum")
+    plt.xlabel("Generation")
+    plt.ylabel("Fitness")
+    plt.legend(loc="lower right")
+    plt.show()

--- a/ADR/parameters_optmizer.py
+++ b/ADR/parameters_optmizer.py
@@ -1,0 +1,116 @@
+# Generate dictionary with plane and takeoff data
+# Ideally you should give all data (like on
+# this example). If you don't use some of it, just give
+# dummy data (zeros or anything).
+
+def enter_parameters(bounds):
+    wing_span = 1 + 1*bounds[0]
+    wing_chord = 0.2 + 0.5*bounds[1]
+    hs_span = 0.3 + 0.7*bounds[2]
+    hs_chord = 0.05 + 0.4*bounds[3]
+
+    airplane_data = [wing_span, wing_chord, hs_span, hs_chord]
+    return airplane_data
+
+def plane_data(data):
+
+    plane_data = {
+        "plane_type": 'monoplane',
+
+        "wing1_x": 0,
+        "wing1_y": 0,
+        "wing1_z": 0,
+        "wing1_clmax_airfoil": 2.2,
+        "wing1_airfoil1_name": "s1223",
+        "wing1_airfoil2_name": "s1223",
+        "wing1_airfoil3_name": "s1223",
+        "wing1_span1": data[0]/4,
+        "wing1_span2": data[0]/4,
+        "wing1_chord1": data[1],
+        "wing1_chord2": data[1],
+        "wing1_chord3": data[1],
+        "wing1_twist1": 0,
+        "wing1_twist2": 0,
+        "wing1_twist3": 0,
+        "wing1_incidence": 0,
+
+        "wing2_x": 0,
+        "wing2_y": 0,
+        "wing2_z": 0.3,
+        "wing2_clmax_airfoil": 2.2,
+        "wing2_airfoil1_name": "s1223",
+        "wing2_airfoil2_name": "s1223",
+        "wing2_airfoil3_name": "s1223",
+        "wing2_span1": 0.45,
+        "wing2_span2": 0.45,
+        "wing2_chord1": 0.25,
+        "wing2_chord2": 0.25,
+        "wing2_chord3": 0.25,
+        "wing2_twist1": 0,
+        "wing2_twist2": 0,
+        "wing2_twist3": 0,
+        "wing2_incidence": 0,
+
+        "hs_x": -0.7,
+        "hs_y": 0,
+        "hs_z": 0,
+        "hs_clmax_airfoil": 2.2,
+        "hs_airfoil1_name": "s1223",
+        "hs_airfoil2_name": "s1223",
+        "hs_airfoil3_name": "s1223",
+        "hs_span1": data[2]/4,
+        "hs_span2": data[2]/4,
+        "hs_chord1": data[3],
+        "hs_chord2": data[3],
+        "hs_chord3": data[3],
+        "hs_twist1": 0,
+        "hs_twist2": 0,
+        "hs_twist3": 0,
+        "hs_incidence": 0,
+
+
+        "vs_x": -0.7,
+        "vs_y": 0,
+        "vs_z": 0,
+        "vs_clmax_airfoil": 2.2,
+        "vs_airfoil1_name": "s1223",
+        "vs_airfoil2_name": "s1223",
+        "vs_airfoil3_name": "s1223",
+        "vs_span1": 0.1,
+        "vs_span2": 0.1,
+        "vs_chord1": 0.2,
+        "vs_chord2": 0.2,
+        "vs_chord3": 0.1,
+        "vs_twist1": 0,
+        "vs_twist2": 0,
+        "vs_twist3": 0,
+        "vs_incidence": 0,
+
+        "motor_x": 0.25,
+        "motor_z": -0.05,
+        "static_thrust": 27,
+        "linear_decay_coefficient": 0.875,
+
+        "cg_x": -0.0725,
+        "cg_z": -0.1,
+
+        "tpr_x": -0.1225,
+        "tpr_z": -0.2,
+
+        "Iyy_TPR": 0.114,
+        "CD_tp": 0.02,
+        "CD_fus": 0.02,
+        "u_k": 0.05
+    }
+
+    return plane_data
+
+def performance_data():
+
+    takeoff_parameters = {
+        "rho_air": 1.225, # Densidade do ar [kg/m^3]
+        "dist_max": 60, # Distancia maxima de decolagem pelo regulamento [m]
+        "offset_pilot": 5 # Distancia antes do fim da pista em que o piloto aciona o profundor [m]
+    }
+
+    return takeoff_parameters

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     url="https://github.com/CeuAzul/ADR",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=['numpy', 'matplotlib', 'pandas'],
+    install_requires=['numpy', 'matplotlib', 'pandas', 'deap'],
     tests_requires=['pytest'],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
The required adaptions were made to the code so a DEAP optmizer could run it:

- main.py now returns a tuple (required by DEAP)
- parameters_optmizer.py was created to adapt the parameters to the optmizer random input
- Assassin now gives score = -1000 to dead aircrafts
- Power analysis doesn't raise error anymore (because it stops the code) and the MTOW reducing iterator now go on 1kg steps (because the iteration takes toooo long).
- Deprecates show_plane() on Plane class as it is old and should be updated
- Gives Vmin = Vstall and Vmax = 25 (saturated) for bad planes
- Disable AVL output on terminal

DEAP is now a requirement for ADR also.

Soves #64 