### PR TITLE
Add wheel to setup_requires on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setuptools.setup(
     url="https://github.com/CeuAzul/ADR",
     packages=setuptools.find_packages(),
     include_package_data=True,
+    setup_requires=['wheel'],
     install_requires=['numpy', 'matplotlib', 'pandas', 'deap', 'scipy'],
     tests_requires=['pytest'],
     classifiers=[


### PR DESCRIPTION
@joaofoes whas having problems installing ADR and we figured out it was the lack of the wheel package in his system.