### PR TITLE
Change from libgfortran3 to gfortran on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.7"
 before_install:
   - sudo apt-get update
-  - sudo apt-get -y install libgfortran3
+  - sudo apt-get -y install gfortran
 install:
   - pip install -e ./
 before_script:


### PR DESCRIPTION
GFortran contains all the necessary dependencies to run AVL