### PR TITLE
Remove AVL build instructions from travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,6 @@ language: python
 python:
   - "3.8"
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install gcc gfortran libx11-dev
-  - git clone https://gitlab.com/relmendorp/avl.git avl_repo
-  - cd avl_repo
-  - make
-  - cd bin
-  - export PATH=$PATH:$(pwd)
-  - cd ..
-  - cd ..
   - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
   - source $HOME/.poetry/env
 install:


### PR DESCRIPTION
AVL is not used for now, so not necessary to build it.
When we reintroduce AVL we can revert this.