### PR TITLE
Modify coverage command on .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ install:
 before_script:
   - pip install coveralls
 script:
-  - coverage run -m pytest
+  - coverage run --source adr -m pytest
 after_script:
   - coveralls


### PR DESCRIPTION
Old command was picking environment libraries instead of just the source code.
New command considers the source code on ./adr only